### PR TITLE
Do not inject GTM script if ember-cli-gtm environment variable is not defined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,8 @@ module.exports = {
   name: 'ember-cli-gtm',
 
   contentFor: function(type, config) {
-    if (type === 'body') {
+    if (type === 'body' && config['ember-cli-gtm']) {
       return "<noscript><iframe src='//www.googletagmanager.com/ns.html?id=" + config['ember-cli-gtm'].appId + "' height='0' width='0' style='display:none;visibility:hidden'></iframe></noscript> <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','" + config['ember-cli-gtm'].appId + "');</script>";
     }
   }
 };
-


### PR DESCRIPTION
This will allow development environment to work without loading GTM.
